### PR TITLE
Fix sorting in availableTimesFromSelectedDate

### DIFF
--- a/composeApp/src/commonMain/kotlin/br/com/cauezito/schedrix/extensions/DateExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/cauezito/schedrix/extensions/DateExtensions.kt
@@ -46,11 +46,11 @@ internal object DateExtensions {
         return "${hour12.toString().padStart(2, '0')}:${minuteStr}\n${amPm}"
     }
 
-    internal fun LocalDate.availableTimesFromSelectedDate(appointments: List<AppointmentDateTime>) =
-        appointments
-            .filter { it.availableAppointmentDateTime.date  == this }
-            .sortedBy { it.availableAppointmentDateTime.time
-    }
+    internal fun LocalDate.availableTimesFromSelectedDate(
+        appointments: List<AppointmentDateTime>
+    ) = appointments
+        .filter { it.availableAppointmentDateTime.date == this }
+        .sortedBy { it.availableAppointmentDateTime.time }
 
     @OptIn(FormatStringsInDatetimeFormats::class)
     internal fun LocalDateTime.formatLocalDateTime(format: String = "yyyy-MM-dd'T'HH:mm"): String {


### PR DESCRIPTION
## Summary
- fix syntax in `availableTimesFromSelectedDate`

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6dea620c8321980055ca64dcf2a6